### PR TITLE
Fix nnsight to 0.2.21

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ datasets>=2.18.0
 einops>=0.7.0
 graphviz>=0.20.1
 matplotlib>=3.8.3
-nnsight>=0.2.9
+nnsight==0.2.21
 numpy>=1.26.4
 pandas>=2.2.1
 plotly>=5.18.0


### PR DESCRIPTION
nnsight 0.3.0 had breaking changes. I verified that `bib_shift.ipynb` ran to completion with nnsight 0.2.21. 0.2.9 did not work due to an error with concept bottleneck probing.